### PR TITLE
js: Declare module export variables with "var"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const ID_PREFIX = 'Q';
 const DEFAULT_WEIGHT = 1;
 const EXACT_WEIGHT = 27;
 
-const Index = new Lang.Class({
+var Index = new Lang.Class({
     Name: 'Index',
 
     _init: function () {

--- a/src/links.js
+++ b/src/links.js
@@ -3,7 +3,7 @@ const Lang = imports.lang;
 const EosShard = imports.gi.EosShard;
 const Gio = imports.gi.Gio;
 
-const Links = new Lang.Class({
+var Links = new Lang.Class({
     Name: 'Links',
 
     _init: function () {

--- a/src/packer.js
+++ b/src/packer.js
@@ -7,7 +7,7 @@ const Index = imports.index;
 const Links = imports.links;
 const Shard = imports.shard;
 
-const Packer = new Lang.Class ({
+var Packer = new Lang.Class ({
     Name: 'Packer',
 
     _init: function (json_path, shard_path) {

--- a/src/shard.js
+++ b/src/shard.js
@@ -3,7 +3,7 @@ const Lang = imports.lang;
 const EosShard = imports.gi.EosShard;
 const Gio = imports.gi.Gio;
 
-const Shard = new Lang.Class({
+var Shard = new Lang.Class({
     Name: 'Shard',
 
     _init: function (path) {


### PR DESCRIPTION
In ES6, variables declared with "const" and "let" go into the "lexical
scope" rather than the normal scope. Therefore, they are not available as
properties on modules. GJS preserves the old behaviour with a warning,
but we should fix our code anyway.

https://phabricator.endlessm.com/T18106