### PR TITLE
util: Fix double free

### DIFF
--- a/lib/basin-util.c
+++ b/lib/basin-util.c
@@ -127,8 +127,10 @@ basin_override_resources (const gchar *content)
           xmlFree (ekn_id);
 
           /* add default thumbnail */
-          xmlAddChild(nodeset->nodeTab[i], (xmlNodePtr) img_node);
+          xmlAddChild (nodeset->nodeTab[i], xmlCopyNode ((xmlNodePtr) img_node, 2));
         }
+
+      xmlFreeDoc (img_node);
     }
   xmlXPathFreeObject(objects);
 


### PR DESCRIPTION
xmlAddChild() takes ownership of the added node, so when the thumbnail
SVG was added to more than one node it would be double-freed later on.
Instead, make a copy when adding it.

Verified with Valgrind that this doesn't do any invalid reads or leak any
memory from libxml.

https://phabricator.endlessm.com/T19955