### PR TITLE
Adapt to name change of ekn_id -> id

### DIFF
--- a/src/links.js
+++ b/src/links.js
@@ -10,8 +10,8 @@ var Links = new Lang.Class({
         this._links = new Map();
     },
 
-    add: function (link, ekn_id) {
-        this._links.set(link, ekn_id);
+    add(link, id) {
+        this._links.set(link, id);
     },
 
     finish: function () {


### PR DESCRIPTION
This change is purely cosmetic, it only changes variable names. We want
to get rid of the term "EKN ID" in favour of just "ID", since we hope
these IDs will be used more widely than just EKN.

Includes a refactor of some duplicate code into a function.

https://phabricator.endlessm.com/T22103