### PR TITLE
packer: Deal gracefully with missing manifest keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ If you want all the categories to be featured, except for *Sports* then your `ha
 }
 ```
 
+If you want only the *Sports* category and no other automatically generated ones, you can use the `ignore-unlisted` key:
+```json
+{
+  "ignore-unlisted": true,
+  "tags": {
+    "Sports": {
+      "featured": true
+    }
+  }
+}
+```
+
 To structure your content with sub-categories, so that *Sports* is a sub-category of *International*:
 
 ```
@@ -136,3 +148,4 @@ To specify a display order for your categories:
 ```
 
 If the `hatch_sets.json` doesn't exist or is empty then all categories will default to non-featured.
+If you don't want `basin-hatch` to create any sets at all, add `ignore-unlisted` and no tags.

--- a/src/index.js
+++ b/src/index.js
@@ -86,9 +86,8 @@ var Index = new Lang.Class({
         doc.add_term_full(EXACT_TITLE_PREFIX + exact_title, EXACT_WEIGHT);
         doc.add_term_full(CONTENT_TYPE_PREFIX + content_type, DEFAULT_WEIGHT);
 
-        metadata['tags'].forEach((tag) => {
-            doc.add_boolean_term(TAG_PREFIX + tag);
-        });
+        if (metadata['tags'])
+            metadata['tags'].forEach(tag => doc.add_boolean_term(TAG_PREFIX + tag));
 
         if ('sequenceNumber' in metadata && metadata['sequenceNumber'] >= 0) {
             doc.add_numeric_value(SEQUENCE_NUMBER_VALUE_NO, metadata['sequenceNumber']);

--- a/src/packer.js
+++ b/src/packer.js
@@ -24,10 +24,12 @@ var Packer = new Lang.Class ({
 
     run: function () {
         print('Writing content');
-        this._json['content'].forEach(this._add_content, this);
+        if (this._json['content'])
+            this._json['content'].forEach(this._add_content, this);
 
         print('Writing sets');
-        this._json['sets'].forEach(this._add_set, this);
+        if (this._json['sets'])
+            this._json['sets'].forEach(this._add_set, this);
 
         print('Writing links');
         let links_hash = this._hashify('link-table');

--- a/tools/incubator.js
+++ b/tools/incubator.js
@@ -15,6 +15,8 @@ const Incubator = new Lang.Class({
         this._basin_manifest_path = basin_manifest_path;
         this._manifest = this._read_json_file(GLib.build_filenamev([this._hatch_dir, 'hatch_manifest.json']));
         this._sets = this._read_json_file(GLib.build_filenamev([this._hatch_dir, 'hatch_sets.json']));
+        if (this._sets && !('tags' in this._sets))
+            this._sets['tags'] = {};
     },
 
     _read_json_file: function (path) {
@@ -174,6 +176,9 @@ const Incubator = new Lang.Class({
     },
 
     _import_set: function (tag) {
+        if (this._sets && this._sets['ignore-unlisted'] && !(tag in this._sets['tags']))
+            return null;
+
         let basin_metadata = {};
 
         basin_metadata['childTags'] = [tag];
@@ -228,6 +233,8 @@ const Incubator = new Lang.Class({
 
         [...basin_tags].forEach(tag => {
             let set_metadata = this._import_set(tag);
+            if (!set_metadata)
+                return;
 
             if ('thumbnail' in set_metadata) {
                 let thumb_metadata = this._import_set_thumbnail(set_metadata['thumbnail']);


### PR DESCRIPTION
If writing a manifest by hand, it's inconvenient to have to list a bunch
of keys with empty array values. Instead, make these keys optional.

https://phabricator.endlessm.com/T16018